### PR TITLE
breaks the gameround if someone wins

### DIFF
--- a/src/gameplay.ts
+++ b/src/gameplay.ts
@@ -31,7 +31,7 @@ const submitBtn: HTMLButtonElement = document.createElement("button");
 let amountOfGuesses: number = 0;
 
 function drawGame() {
-
+  correctGuessMade = false;
   chosenBots.splice(1, 0, "Player");
   drawSlider();
   drawBubbles();
@@ -41,6 +41,7 @@ function drawGame() {
   document.getElementById('answer1').style.backgroundImage = `url("../assets/imgs/thinkBubble.png")`
   updateAnswers('answer1', bubblePhrases[Math.floor(Math.random() * (0 + bubblePhrases.length) + 0)]);
   gameRound();
+  
   //   hideAnswerBubbles();
 }
 
@@ -128,9 +129,15 @@ let botOneAnswer: number;
 let botTwoAnswer: number;
 let guessValue: number;
 let answerTime: number;
+let correctGuessMade: boolean;
 
 // the logic for how the rounds works----
 function gameRound() {
+  
+  //If someone wins the gameround breaks/ends
+  if (correctGuessMade === true){
+    return;
+  }
 
   //sets a random number between 2000-4000 to use as timeout time.
   answerTime = Math.floor(Math.random() * (6000 - 3000 + 1000) + 3000);
@@ -245,6 +252,7 @@ function compareAnswer(answer: number, randomNumber: number) {
     setElementContent(bubbleTextID[1], gpPhrases[1]);
     amountOfGuesses++;
     checkWhoWon();
+    correctGuessMade = true;
   } else if (answer > randomNumber) {
     //IF GUESST IS HIGHER THAN RANDOMNUMB
     document.getElementById(bubbleID[0]).style.visibility = "hidden";

--- a/src/winner.ts
+++ b/src/winner.ts
@@ -11,7 +11,9 @@ function checkWhoWon() {
 
 /** Draws winnermodal and the right lottie-animation */
 function drawWinnerScreen(winner: string) {
-  updateGamesPlayed();
+  document.getElementById("winner").style.display = "none";
+  document.getElementById("playerWinner").style.display = "none";
+
   const modal: HTMLElement | null = document.getElementById("winnerModal");
   modal.style.opacity = "1";
   modal.style.visibility = "visible";
@@ -66,6 +68,7 @@ function restartGame() {
 
 /** Hides all element from Gameplay */
 function hideGamePlay() {
+  updateGamesPlayed();
   removeBubbles();
   removeBubble(bubbleID[0] , bubbleTextID[0])
   //Hides inputfield and button


### PR DESCRIPTION
Förut (speciellt om man endast spelade med en bot) kunde man se att timer-bubblan kunde dyka upp igen vid omstart av spel. För att få bort detta har jag lagt in en ny variabel som är ''correctguessmade'' och när den sätts till true(som den alltså görs när någon gissar rätt) så breakar vi gameround funktionen. Den sätts sedan till true varje gång gameplay ritas upp. :-)